### PR TITLE
Add file attachment URL fields to clinical tables

### DIFF
--- a/historia_clinica.sql
+++ b/historia_clinica.sql
@@ -43,10 +43,12 @@ CREATE TABLE `HistoriaClinica` (
   `tipo_sangre` enum('A+','A-','B+','B-','AB+','AB-','O+','O-') CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL,
   `porte_clinico` text COLLATE utf8mb4_unicode_ci COMMENT 'Campo específico para visitas domiciliarias donde el profesional registra toda la consulta realizada',
   `id_profesional` int DEFAULT NULL,
+  `url_hc_adjunto` text CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci COMMENT 'URL del archivo adjunto de la historia clínica almacenado en S3',
   PRIMARY KEY (`id_historiaclinica`),
   KEY `id_usuario` (`id_usuario`),
   KEY `idx_porte_clinico` (`porte_clinico`(255)),
   KEY `fk_historiaclinica_profesional` (`id_profesional`),
+  KEY `idx_url_hc_adjunto` (`url_hc_adjunto`(255)),
   CONSTRAINT `fk_historiaclinica_profesional` FOREIGN KEY (`id_profesional`) REFERENCES `Profesionales` (`id_profesional`),
   CONSTRAINT `HistoriaClinica_ibfk_1` FOREIGN KEY (`id_usuario`) REFERENCES `Usuarios` (`id_usuario`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;

--- a/reporte_clinico.sql
+++ b/reporte_clinico.sql
@@ -30,9 +30,11 @@ CREATE TABLE `ReportesClinicos` (
   `saturacionOxigeno` int DEFAULT NULL,
   `temperatura_corporal` float DEFAULT NULL,
   `tipo_reporte` text CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci,
+  `url_adjunto` text CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci COMMENT 'URL del archivo adjunto del reporte clínico almacenado en S3',
   PRIMARY KEY (`id_reporteclinico`),
   KEY `id_historiaclinica` (`id_historiaclinica`),
   KEY `id_profesional` (`id_profesional`),
+  KEY `idx_url_adjunto` (`url_adjunto`(255)),
   CONSTRAINT `ReportesClinicos_ibfk_1` FOREIGN KEY (`id_historiaclinica`) REFERENCES `HistoriaClinica` (`id_historiaclinica`) ON DELETE CASCADE,
   CONSTRAINT `ReportesClinicos_ibfk_2` FOREIGN KEY (`id_profesional`) REFERENCES `Profesionales` (`id_profesional`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
@@ -98,7 +100,7 @@ CREATE TABLE `DocumentoAdjuntoExam` (
 
 CREATE TABLE `Profesionales` (
   `id_profesional` int NOT NULL AUTO_INCREMENT,
-  `id_user` int,
+  `id_user` int DEFAULT NULL,
   `nombres` varchar(35) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci DEFAULT NULL,
   `apellidos` varchar(35) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci DEFAULT NULL,
   `n_documento` varchar(25) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci DEFAULT NULL,
@@ -109,9 +111,10 @@ CREATE TABLE `Profesionales` (
   `profesion` enum('Médico','Enfermero','Nutricionista','Psicólogo','Fisioterapeuta') CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci DEFAULT NULL,
   `especialidad` enum('Cardiología','Pediatría','Nutrición','Psicología Clínica','Fisioterapia') CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci DEFAULT NULL,
   `cargo` enum('Jefe de Departamento','Especialista','Residente') CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci DEFAULT NULL,
-  `telefono` varchar(35) DEFAULT NULL,
+  `telefono` varchar(35) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci DEFAULT NULL,
   `e_mail` varchar(30) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci DEFAULT NULL,
   `direccion` varchar(50) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci DEFAULT NULL,
   PRIMARY KEY (`id_profesional`),
-  FOREIGN KEY (`id_user`) REFERENCES `users` (`id`)
+  KEY `id_user` (`id_user`),
+  CONSTRAINT `Profesionales_ibfk_1` FOREIGN KEY (`id_user`) REFERENCES `users` (`id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;

--- a/users.sql
+++ b/users.sql
@@ -5,7 +5,7 @@ CREATE TABLE `users` (
   `last_name` varchar(50) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL,
   `password` varchar(255) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL,
   `is_deleted` tinyint(1) DEFAULT '0',
-  `role` enum('admin', 'profesional', 'transporte'),
+  `role` enum('admin','profesional','transporte') CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci DEFAULT NULL,
   PRIMARY KEY (`id`),
   UNIQUE KEY `email` (`email`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;


### PR DESCRIPTION
Added 'url_hc_adjunto' to 'HistoriaClinica' and 'url_adjunto' to 'ReportesClinicos' for storing S3 file URLs, along with corresponding indexes. Also updated 'Profesionales' and 'users' table definitions for improved consistency and foreign key constraints.